### PR TITLE
G201の二重助詞となるタイトルを修正

### DIFF
--- a/wcag20/sources/techniques/general/G201.xml
+++ b/wcag20/sources/techniques/general/G201.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE technique
   SYSTEM "../../xmlspec.dtd">
 <technique id="G201">
-   <short-name>新しいウィンドウを開くときには利用者に事前に知らせる</short-name>
+   <short-name>新しいウィンドウを開くときには利用者へ事前に知らせる</short-name>
    <applicability>
       <p>新しいウィンドウを開くウェブページ</p>
    </applicability>


### PR DESCRIPTION
### 修正内容

達成方法集のG201のタイトルが二重助詞となっていたため修正させていただきました。

### 目的

textlintの[textlint-rule-no-doubled-joshi ](https://github.com/textlint-ja/textlint-rule-no-doubled-joshi )の項目に引っかかり、G201をリンクするとlintエラーになってしまうため修正したく。

不備などありましたらご指摘ください:bow: