### PR TITLE
セルフレビューSC1.4.7

### DIFF
--- a/wcag20/sources/understanding/visual-audio-contrast-noaudio.xml
+++ b/wcag20/sources/understanding/visual-audio-contrast-noaudio.xml
@@ -7,7 +7,7 @@
       <head>この達成基準の意図</head>
 
 <p>この達成基準の意図は、発話ではないあらゆる音が、音声の聞こえづらい利用者が発話を背景音又は前景にある不要な他の発話コンテンツと区別することができるようにすることである。</p>
-<p>20 dB（デシベル）という値は、 Large area assistive listening systems (ALS): Review and recommendations <bibref ref="LAALS"/>と、In-the-ear measurements of interference in hearing aids from digital wireless telephones <bibref ref="HEARING-AID-INT"/> に基づいている。</p>
+<p>20 デシベルという値は、 Large area assistive listening systems (ALS): Review and recommendations <bibref ref="LAALS"/>と、In-the-ear measurements of interference in hearing aids from digital wireless telephones <bibref ref="HEARING-AID-INT"/> に基づいている。</p>
 
 <div4 role="benefits">
 <head/>


### PR DESCRIPTION
Close #41
単位を繰り返す必要はないので、WCAG 2.0本体にあわせてカタカナのみに。
speechを発話とするのが個人的には微妙な感じもしますが、WCAG 2.0本体訳でそうしているのでとりあえずこのままに。
