### PR TITLE
F68のタイトルの調整

### DIFF
--- a/wcag20/sources/techniques/failures/F68.xml
+++ b/wcag20/sources/techniques/failures/F68.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE technique
   SYSTEM "../../xmlspec.dtd">
 <technique id="F68">
-   <short-name>達成基準 4.1.2 の失敗例 － プログラム的に解釈される名前 (name) を持っていないユーザインタフェース コントロール</short-name>
+   <short-name>達成基準 4.1.2 の失敗例 － プログラムによる解釈される名前 (name) を持っていないユーザインタフェース コントロール</short-name>
    <applicability>
       <p>HTML のコントロール</p>
    </applicability>

--- a/wcag20/sources/techniques/failures/F68.xml
+++ b/wcag20/sources/techniques/failures/F68.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE technique
   SYSTEM "../../xmlspec.dtd">
 <technique id="F68">
-   <short-name>達成基準 4.1.2 の失敗例 － プログラムによる解釈される名前 (name) を持っていないユーザインタフェース コントロール</short-name>
+   <short-name>達成基準 4.1.2 の失敗例 － プログラムによる解釈が可能な名前 (name) を持っていないユーザインタフェース コントロール</short-name>
    <applicability>
       <p>HTML のコントロール</p>
    </applicability>


### PR DESCRIPTION
現行：
> F68: 達成基準 4.1.2 の失敗例 － プログラム的に解釈される名前 (name) を持っていないユーザインタフェース コントロール
F68: Failure of Success Criterion 4.1.2 due to a user interface control not having a programmatically determined name

programmatically determined = プログラムによる解釈
について調整したものです。
