### PR TITLE
linktype=examplesの参照URLをW3Cに修正

### DIFF
--- a/wcag20/sources/techniques/failures/F90.xml
+++ b/wcag20/sources/techniques/failures/F90.xml
@@ -49,8 +49,8 @@
 							]]></codeblock>
             <p>
                <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="incorrectassociation"
-                    linktype="examples">Failure example of table incorrectly associating headers attributes in table content (td) to table headers (th)</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/F90/incorrectassociation">
+                    <!--linktype="examples"-->Failure example of table incorrectly associating headers attributes in table content (td) to table headers (th)</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/failures/F91.xml
+++ b/wcag20/sources/techniques/failures/F91.xml
@@ -83,8 +83,8 @@
 							]]></codeblock>
             <p>
                <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="td-not-th.html"
-                    linktype="examples">View example 1 (opens in same browser window)</loc>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/F91/td-not-th.html">
+                    <!--linktype="examples"-->View example 1 (opens in same browser window)</loc>
 							     </p>
          </description>
       </eg-group>

--- a/wcag20/sources/techniques/silverlight/SL1.xml
+++ b/wcag20/sources/techniques/silverlight/SL1.xml
@@ -131,8 +131,8 @@
             media.Play();
         }]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="AlternativeAudioChannelTestPage.html"
-                    linktype="examples">working example of Alternative Audio Channel</loc>. If using the test file, the test contains test audio tones rather than actual audio description, but the pitch of the tones is indicative of which of the channels is selected and played. </p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL1/AlternativeAudioChannelTestPage.html">
+                    <!--linktype="examples"-->working example of Alternative Audio Channel</loc>. If using the test file, the test contains test audio tones rather than actual audio description, but the pitch of the tones is indicative of which of the channels is selected and played. </p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL10.xml
+++ b/wcag20/sources/techniques/silverlight/SL10.xml
@@ -122,8 +122,8 @@
 }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="BasicSubmitButtonTestPage.html"
-                    linktype="examples">working example of Basic Submit Button</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL10/BasicSubmitButtonTestPage.html">
+                    <!--linktype="examples"-->working example of Basic Submit Button</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL11.xml
+++ b/wcag20/sources/techniques/silverlight/SL11.xml
@@ -96,8 +96,8 @@ xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
        }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="PauseBouncyBall.html"
-                    linktype="examples">working example of Pause Bouncy Ball</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL11/PauseBouncyBall.html">
+                    <!--linktype="examples"-->working example of Pause Bouncy Ball</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL13.xml
+++ b/wcag20/sources/techniques/silverlight/SL13.xml
@@ -227,8 +227,8 @@
                </image> 
             </p>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="HighContrastTestPage.html"
-                    linktype="examples">working example of High Contrast</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL13/HighContrastTestPage.html">
+                    <!--linktype="examples"-->working example of High Contrast</loc>.</p>
          </description>
       </eg-group>
       <eg-group>

--- a/wcag20/sources/techniques/silverlight/SL14.xml
+++ b/wcag20/sources/techniques/silverlight/SL14.xml
@@ -245,8 +245,8 @@
             <codeblock xml:space="preserve"><![CDATA[<local:KeysNumericUpDown Width="100" Height="45"/>
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="SimpleNumericUpDownTestPage.html"
-                    linktype="examples">working example of Numeric Up / Down control</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL14/SimpleNumericUpDownTestPage.html">
+                    <!--linktype="examples"-->working example of Numeric Up / Down control</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL15.xml
+++ b/wcag20/sources/techniques/silverlight/SL15.xml
@@ -197,8 +197,8 @@
 
         }]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="ApplicationLevelKeyHandlingTestPage.html"
-                    linktype="examples">working example of Application Level Key Handling</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL15/ApplicationLevelKeyHandlingTestPage.html">
+                    <!--linktype="examples"-->working example of Application Level Key Handling</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL16.xml
+++ b/wcag20/sources/techniques/silverlight/SL16.xml
@@ -93,8 +93,8 @@ private void OnMarkerReached(object sender, TimelineMarkerRoutedEventArgs e)
 }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="MediaTimelineMarkersTestPage.html"
-                    linktype="examples">working example of Media Timeline Markers</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL16/MediaTimelineMarkersTestPage.html">
+                    <!--linktype="examples"-->working example of Media Timeline Markers</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL17.xml
+++ b/wcag20/sources/techniques/silverlight/SL17.xml
@@ -134,8 +134,8 @@ First Lady Michelle Obama will serve as honorary chairs of this free event. </sy
        }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="ReplaceAudioWithTranscriptTextTestPage.html"
-                    linktype="examples">working example of Replace Audio With Transcript</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL17/ReplaceAudioWithTranscriptTextTestPage.html">
+                    <!--linktype="examples"-->working example of Replace Audio With Transcript</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL18.xml
+++ b/wcag20/sources/techniques/silverlight/SL18.xml
@@ -70,8 +70,8 @@
  </Button>
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="ButtonNontextTextCompositionTestPage.html"
-                    linktype="examples">working example of Button Text Alternative</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL18/ButtonNontextTextCompositionTestPage.html">
+                    <!--linktype="examples"-->working example of Button Text Alternative</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL19.xml
+++ b/wcag20/sources/techniques/silverlight/SL19.xml
@@ -170,8 +170,8 @@ door, and one file cabinet against the same wall as the door.”/>
                </item>
             </ulist>
             <p>These examples are shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="AutomationPropertiesHelpTextTestPage.html"
-                    linktype="examples">working example of Automation Properties Help Text</loc> and <loc xmlns:xlink="http://www.w3.org/1999/xlink"
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL19/AutomationPropertiesHelpTextTestPage.html">
+                    <!--linktype="examples"-->working example of Automation Properties Help Text</loc> and <loc xmlns:xlink="http://www.w3.org/1999/xlink"
                     href="/WAI/WCAG20/Techniques/working-examples/SL8/HelpTextAndToolTipTestPage.html">working example of HelpText and ToolTip</loc>.</p>
          </description>
       </eg-group>

--- a/wcag20/sources/techniques/silverlight/SL2.xml
+++ b/wcag20/sources/techniques/silverlight/SL2.xml
@@ -180,8 +180,8 @@
                </image> 
             </p>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="VisibleFocusTemplateTestPage.html"
-                    linktype="examples">working example of Visible Focus Template</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL2/VisibleFocusTemplateTestPage.html">
+                    <!--linktype="examples"-->working example of Visible Focus Template</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL20.xml
+++ b/wcag20/sources/techniques/silverlight/SL20.xml
@@ -127,8 +127,8 @@
                </image> 
             </p>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="SimplePeerForwardingTestPage.html"
-                    linktype="examples">working example of Simple Peer Forwarding</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL20/SimplePeerForwardingTestPage.html">
+                    <!--linktype="examples"-->working example of Simple Peer Forwarding</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL21.xml
+++ b/wcag20/sources/techniques/silverlight/SL21.xml
@@ -97,8 +97,8 @@ xmlns:sys="clr-namespace:System;assembly=mscorlib">
        }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="StopAnimationTestPage.html"
-                    linktype="examples">working example of Stop Text Animation</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL21/StopAnimationTestPage.html">
+                    <!--linktype="examples"-->working example of Stop Text Animation</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL22.xml
+++ b/wcag20/sources/techniques/silverlight/SL22.xml
@@ -137,8 +137,8 @@
    }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="BrowserZoomTestPage.html"
-                    linktype="examples">working example of Browser Zoom</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL22/BrowserZoomTestPage.html">
+                    <!--linktype="examples"-->working example of Browser Zoom</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL23.xml
+++ b/wcag20/sources/techniques/silverlight/SL23.xml
@@ -156,8 +156,8 @@ private void Undo_Click(object sender, RoutedEventArgs e)
                </image> 
             </p>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="StyleSwitcherFontSizeTestPage.html"
-                    linktype="examples">working example of Style Switcher Font Size</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL23/StyleSwitcherFontSizeTestPage.html">
+                    <!--linktype="examples"-->working example of Style Switcher Font Size</loc>.</p>
          </description>
       </eg-group>
       <eg-group>
@@ -202,8 +202,8 @@ private void Undo_Click(object sender, RoutedEventArgs e)
 ]]></codeblock>
             <p>
                 This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="ByAnimationFontSizeTestPage.html"
-                    linktype="examples">working example of By Animation Font Size</loc>.
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL23/ByAnimationFontSizeTestPage.html">
+                    <!--linktype="examples"-->working example of By Animation Font Size</loc>.
               </p>
          </description>
       </eg-group>

--- a/wcag20/sources/techniques/silverlight/SL24.xml
+++ b/wcag20/sources/techniques/silverlight/SL24.xml
@@ -103,8 +103,8 @@
  
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="MediaElementControlsAutoPlayTestPage.html"
-                    linktype="examples">working example of Media Element Controls with AutoPlay False</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL24/MediaElementControlsAutoPlayTestPage.html">
+                    <!--linktype="examples"-->working example of Media Element Controls with AutoPlay False</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL25.xml
+++ b/wcag20/sources/techniques/silverlight/SL25.xml
@@ -65,8 +65,8 @@
        }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="ProgrammaticFocusTestPage.html"
-                    linktype="examples">working example of Programmatic Focus</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL25/ProgrammaticFocusTestPage.html">
+                    <!--linktype="examples"-->working example of Programmatic Focus</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL26.xml
+++ b/wcag20/sources/techniques/silverlight/SL26.xml
@@ -58,8 +58,8 @@
    </StackPanel>
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="LabelsTestPage.html"
-                    linktype="examples">working example of Labels</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL26/LabelsTestPage.html">
+                    <!--linktype="examples"-->working example of Labels</loc>.</p>
          </description>
       </eg-group>
       <eg-group>

--- a/wcag20/sources/techniques/silverlight/SL27.xml
+++ b/wcag20/sources/techniques/silverlight/SL27.xml
@@ -284,8 +284,8 @@ private void button1_Click(object sender, RoutedEventArgs e)
 }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="LangPropertiesTestPage.html"
-                    linktype="examples">working example of Language Properties</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL27/LangPropertiesTestPage.html">
+                    <!--linktype="examples"-->working example of Language Properties</loc>.</p>
          </description>
       </eg-group>
       <eg-group>

--- a/wcag20/sources/techniques/silverlight/SL29.xml
+++ b/wcag20/sources/techniques/silverlight/SL29.xml
@@ -164,8 +164,8 @@
                </image> 
             </p>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="TabNavigationTestPage.html"
-                    linktype="examples">working example of Tab Navigation</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL29/TabNavigationTestPage.html">
+                    <!--linktype="examples"-->working example of Tab Navigation</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL3.xml
+++ b/wcag20/sources/techniques/silverlight/SL3.xml
@@ -128,8 +128,8 @@
  }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="MediaElementControlsTestPage.html"
-                    linktype="examples">working example of Media Element Controls</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL3/MediaElementControlsTestPage.html">
+                    <!--linktype="examples"-->working example of Media Element Controls</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL30.xml
+++ b/wcag20/sources/techniques/silverlight/SL30.xml
@@ -88,8 +88,8 @@
  </Button>
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="ButtonNontextTextCompositionTestPage.html"
-                    linktype="examples">working example of Button Nontext Text Composition</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL30/ButtonNontextTextCompositionTestPage.html">
+                    <!--linktype="examples"-->working example of Button Nontext Text Composition</loc>.</p>
          </description>
       </eg-group>
       <eg-group>

--- a/wcag20/sources/techniques/silverlight/SL31.xml
+++ b/wcag20/sources/techniques/silverlight/SL31.xml
@@ -199,8 +199,8 @@ then is this? Are the green fields gone? What do they here?
        }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="DocumentStructureTestPage.html"
-                    linktype="examples">working example of Document Structure</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL31/DocumentStructureTestPage.html">
+                    <!--linktype="examples"-->working example of Document Structure</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL34.xml
+++ b/wcag20/sources/techniques/silverlight/SL34.xml
@@ -143,8 +143,8 @@
    </StackPanel>
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="TabSequenceTestPage.html"
-                    linktype="examples">working example of Tab Sequence</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL34/TabSequenceTestPage.html">
+                    <!--linktype="examples"-->working example of Tab Sequence</loc>.</p>
          </description>
       </eg-group>
       <eg-group>
@@ -196,8 +196,8 @@
  </UserControl>
  ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="TabSequence_TabIndexTestPage.html"
-                    linktype="examples">working example of Tab Sequence TabIndex</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL34/TabSequence_TabIndexTestPage.html">
+                    <!--linktype="examples"-->working example of Tab Sequence TabIndex</loc>.</p>
          </description>
       </eg-group>
       <eg-group>
@@ -253,8 +253,8 @@
        }
        ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="TabSequence_EnabledTestPage.html"
-                    linktype="examples">working example of Tab Sequence Enabled</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL34/TabSequence_EnabledTestPage.html">
+                    <!--linktype="examples"-->working example of Tab Sequence Enabled</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL35.xml
+++ b/wcag20/sources/techniques/silverlight/SL35.xml
@@ -272,8 +272,8 @@
                </image> 
             </p>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="AccessibleValidationTestPage.html"
-                    linktype="examples">working example of Accessible Validation</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL35/AccessibleValidationTestPage.html">
+                    <!--linktype="examples"-->working example of Accessible Validation</loc>.</p>
             <section>
                <head> Validation style for Label controls </head>
                <p>The default validation style for the Invalid state of <obj>Label</obj> does

--- a/wcag20/sources/techniques/silverlight/SL4.xml
+++ b/wcag20/sources/techniques/silverlight/SL4.xml
@@ -177,8 +177,8 @@
    }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="SilverFishTestPage.html"
-                    linktype="examples">working example of SilverFish</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL4/SilverFishTestPage.html">
+                    <!--linktype="examples"-->working example of SilverFish</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL5.xml
+++ b/wcag20/sources/techniques/silverlight/SL5.xml
@@ -163,8 +163,8 @@ xmlns:local="clr-namespace:ImageEquivalent">
 }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="ImageEquivalentTestPage.html"
-                    linktype="examples">working example of Focusable Image</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL5/ImageEquivalentTestPage.html">
+                    <!--linktype="examples"-->working example of Focusable Image</loc>.</p>
          </description>
       </eg-group>
       <eg-group>

--- a/wcag20/sources/techniques/silverlight/SL6.xml
+++ b/wcag20/sources/techniques/silverlight/SL6.xml
@@ -153,8 +153,8 @@
        }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="SimpleNumericUpDownTestPage.html"
-                    linktype="examples">working example of Simple Numeric UpDown control</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL6/SimpleNumericUpDownTestPage.html">
+                    <!--linktype="examples"-->working example of Simple Numeric UpDown control</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL7.xml
+++ b/wcag20/sources/techniques/silverlight/SL7.xml
@@ -252,8 +252,8 @@
        }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="FocusVisualCustomControlTestPage.html"
-                    linktype="examples">working example of Visual Focus Indicator</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL7/FocusVisualCustomControlTestPage.html">
+                    <!--linktype="examples"-->working example of Visual Focus Indicator</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL8.xml
+++ b/wcag20/sources/techniques/silverlight/SL8.xml
@@ -231,8 +231,8 @@ door, and one file cabinet against the same wall as the door.”/>
                </image> 
             </p>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="HelpTextAndToolTipTestPage.html"
-                    linktype="examples">working example of HelpText and Tooltip</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL8/HelpTextAndToolTipTestPage.html">
+                    <!--linktype="examples"-->working example of HelpText and Tooltip</loc>.</p>
          </description>
       </eg-group>
    </examples>

--- a/wcag20/sources/techniques/silverlight/SL9.xml
+++ b/wcag20/sources/techniques/silverlight/SL9.xml
@@ -218,8 +218,8 @@
     }
 ]]></codeblock>
             <p>This example is shown in operation in the <loc xmlns:xlink="http://www.w3.org/1999/xlink"
-                    href="BuiltInKeyEquivalenceTestPage.html"
-                    linktype="examples">working example of built-in keyboard equivalents</loc>.</p>
+                    href="https://www.w3.org/WAI/WCAG20/Techniques/working-examples/SL9/BuiltInKeyEquivalenceTestPage.html">
+                    <!--linktype="examples"-->working example of built-in keyboard equivalents</loc>.</p>
          </description>
       </eg-group>
       <eg-group>


### PR DESCRIPTION
per #175
リンクURLをW3Cに向くように修正しました。
リンクテキストに関しては、後ほど検討。