### PR TITLE
解説書・達成方法集の別バージョンリンクの修正

### DIFF
--- a/wcag20/sources/guide-to-wcag2-src.xml
+++ b/wcag20/sources/guide-to-wcag2-src.xml
@@ -27,7 +27,7 @@
 <altlocs>
 <loc href="complete.html">単一ファイル版</loc>
 	<!--loc href="complete-diff.html">差分を示した単一ファイル版</loc-->
-	<loc href="http://www.w3.org/WAI/WCAG20/versions/understanding/">Understanding WCAG 2.0 のその他のバージョン (英語)</loc>
+	<loc href="https://www.w3.org/WAI/WCAG20/versions/understanding/">Alternate Versions of Understanding WCAG 2.0</loc>
 </altlocs>
 <latestloc>
 	<loc href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/">https://www.w3.org/TR/UNDERSTANDING-WCAG20/</loc>

--- a/wcag20/sources/wcag20-merged-techs.xml
+++ b/wcag20/sources/wcag20-merged-techs.xml
@@ -27,9 +27,9 @@
 		<altlocs>
 			<loc href="complete.html">単一ファイル版</loc>
 <!-- diff版はいったんナシ
-			<loc href="complete-diff.html">Single file diff-marked version showing revisions since 17 March 2015</loc>
-			<loc href="/WAI/WCAG20/versions/techniques/">Alternate Versions of Techniques for WCAG 2.0</loc>
--->
+			<loc href="complete-diff.html">Single file diff-marked version showing revisions since 17 March 2015</loc> -->
+			<loc href="https://www.w3.org/WAI/WCAG20/versions/techniques/">Alternate Versions of Techniques for WCAG 2.0</loc>
+
 		</altlocs>
 		<latestloc>
 			<loc href="https://www.w3.org/TR/WCAG20-TECHS/">https://www.w3.org/TR/WCAG20-TECHS/</loc>

--- a/wcag20/sources/xmlspec-wcag.xsl
+++ b/wcag20/sources/xmlspec-wcag.xsl
@@ -1236,23 +1236,22 @@
       <!-- BBC: Suppress output of these links in diff-marked version -->
       <!--xsl:if test="$show.diff.markup = 1"-->
     <p>
-      <xsl:text>この文書は、規定ではないフォーマットでも提供されており、</xsl:text>
-<a href="http://www.w3.org/WAI/WCAG20/versions/guidelines/" hreflang="en">Alternate Versions of Web Content Accessibility Guidelines 2.0</a> より入手できる。
+      <xsl:text>この文書は、次の規定ではないフォーマットでも入手できる:</xsl:text>
     </p>
-    <!--ul>
+    <ul>
       <xsl:for-each select="loc">
         <li>
           <xsl:apply-templates select="."/>
-          <xsl:if test="position() &gt; 1">
+          <!--xsl:if test="position() &gt; 1">
             <xsl:if test="last() &gt; 2">
               <xsl:text>,</xsl:text>
             </xsl:if>
             <xsl:text> </xsl:text>
             <xsl:if test="position() = last() - 1">and </xsl:if>
-          </xsl:if>
+          </xsl:if-->
         </li>
       </xsl:for-each>
-    </ul-->
+    </ul>
           <!--/xsl:if-->
   </xsl:template>
   <xsl:template match="p" mode="label">


### PR DESCRIPTION
Fix #222 
達成方法集だけでなく、解説書についても該当部の別バージョンのリンクテキスト下線を修正（`<p>`では適用されない）。

あわせて、既存の日本語訳ではリンクを決め打ちにしていたが、これは達成方法集にも適用されるので、日本語訳からのリンクは不適切な状態だった。

→XSLTのテンプレートを原文と同様に適用させることで、あるべきリンクURLに修正した。
→リストに","や"and"が入らないようにコメントアウトしている