### PR TITLE
MSDNの訳注の追加

### DIFF
--- a/wcag20/sources/techniques/client-side-script/SCR29.xml
+++ b/wcag20/sources/techniques/client-side-script/SCR29.xml
@@ -121,6 +121,9 @@
                </p>
             </item>
          </ulist>
+         <trnote>
+           <p>MSDN のページ「Internet Explorer, HTML and DHTML Reference, tabIndex Property」が MDN にリダイレクトされているが、これは MSDN の文書が MDN に統合されたためである。このリダイレクト処理の詳細については、<a href="https://blogs.windows.com/msedgedev/2017/10/18/documenting-web-together-mdn-web-docs/">Microsoft Edge Dev Blog</a> 及び<a href="https://news.mynavi.jp/article/20171019-a070/">マイナビニュース</a>を参照されたい。</p>
+         </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/client-side-script/SCR34.xml
+++ b/wcag20/sources/techniques/client-side-script/SCR34.xml
@@ -83,6 +83,9 @@ objAlign.style.top = calculatePosition(objReference, 'offsetTop') + objReference
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>「MSDN: Fix the Box Instead of Thinking Outside It」はリソースがリダイレクトされているが適切に処理されていない。代わりに、MDN の <a href="https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetHeight">HTMLElement.offsetHeight</a>、<a href="https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetWidth">HTMLElement.offsetWidth</a>、<a href="https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetLeft">HTMLElement.offsetLeft</a>、<a href="https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetTop">HTMLElement.offsetTop</a> をそれぞれ参照できる。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>


### PR DESCRIPTION
related #153

MSDN のリダイレクトに関する注記の追加（SCR29、SCR34）。

- SCR29に関しては、リダイレクトの理由を追記（不要かもしれない）
- SCR34に関しては、MSDN内でリダイレクトされているが、リダイレクト先があまり適当ではないために、MDNのリソースを追記。