### PR TITLE
パンくずリストへの訳注の追加

### DIFF
--- a/wcag20/sources/techniques/general/G65.xml
+++ b/wcag20/sources/techniques/general/G65.xml
@@ -70,6 +70,9 @@
             </item>
          </ulist>
       </see-also>
+      <trnote>
+        <p>「Bread crumb navigation」への<a href="https://www.w3.org/TR/html5/common-idioms-without-dedicated-elements.html#bread-crumb-navigation">正確なリンクはこのようになる</a>。また、<a href="https://developers.google.com/search/docs/data-types/breadcrumb">パンくずリスト  |  検索  |  Google Developers</a> 及び <a href="https://www.bing.com/webmaster/help/markup-breadcrumbs-72419f3f">Markup: Breadcrumbs - Bing Webmaster Tools</a> もあわせて参考になる。</p>
+      </trnote>
    </resources>
    <related-techniques>
       <relatedtech idref="G63"/>

--- a/wcag20/sources/techniques/general/G65.xml
+++ b/wcag20/sources/techniques/general/G65.xml
@@ -71,7 +71,7 @@
          </ulist>
       </see-also>
       <trnote>
-        <p>「Bread crumb navigation」への<a href="https://www.w3.org/TR/html5/common-idioms-without-dedicated-elements.html#bread-crumb-navigation">正確なリンクはこのようになる</a>。また、<a href="https://developers.google.com/search/docs/data-types/breadcrumb">パンくずリスト  |  検索  |  Google Developers</a> 及び <a href="https://www.bing.com/webmaster/help/markup-breadcrumbs-72419f3f">Markup: Breadcrumbs - Bing Webmaster Tools</a> もあわせて参考になる。</p>
+        <p>「Bread crumb navigation」への正確なリンクは、<a href="https://www.w3.org/TR/html5/common-idioms-without-dedicated-elements.html#bread-crumb-navigation">HTML5.2 4.13.2. Bread crumb navigation</a> となる。また、<a href="https://developers.google.com/search/docs/data-types/breadcrumb">パンくずリスト  |  検索  |  Google Developers</a> 及び <a href="https://www.bing.com/webmaster/help/markup-breadcrumbs-72419f3f">Markup: Breadcrumbs - Bing Webmaster Tools</a> もあわせて参考になる。</p>
       </trnote>
    </resources>
    <related-techniques>


### PR DESCRIPTION
related #153

パンくずリストへのリンク（フラグメント識別子）が古いので、正確なリンクを指示。
あわせて、GoogleとBingのリソースも挙げている。