### PR TITLE
双方向テキストに関する訳注の追加

### DIFF
--- a/wcag20/sources/techniques/html/H34.xml
+++ b/wcag20/sources/techniques/html/H34.xml
@@ -12,7 +12,7 @@
    <description>
     <p>この達成方法の目的は、HTML の双方向性アルゴリズムが望ましくない結果を生じるとき時に、それを無効にするために Unicode 制御文字の right-to-left mark と left-to-right mark を用いることである。たとえば、スペース又は句読点のようなニュートラルな文字が異なる方向性のテキストの間に置かれている時に必要となることがある。この達成方法で用いられているコンセプトは、W3C 文書の「<loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.w3.org/International/articles/inline-bidi-markup/">What you need to know about the bidi algorithm and inline markup</loc>」に書かれている。</p>
     <trnote>
-      <p>上記の「What you need to know about the bidi algorithm and inline markup」は、「Inline markup and bidirectional text in HTML」とタイトルが変更されている。この文書によれば、Unicode の right-to-left mark (RLM) 又は left-to-right mark (LRM) よりも、<code>dir</code> 属性による書字方向の制御が勧められている。<loc href="H56" linktype="html"/>も参照のこと。</p>
+      <p>上記の「What you need to know about the bidi algorithm and inline markup」は、「Inline markup and bidirectional text in HTML」とタイトルが変更されている。また、<a href="https://www.w3.org/International/questions/qa-bidi-controls">Unicode controls vs. markup for bidi support</a> によれば、Unicode の right-to-left mark (RLM) 又は left-to-right mark (LRM) よりも、<code>dir</code> 属性による書字方向の制御が勧められている。<loc href="H56" linktype="html"/>も参照のこと。</p>
     </trnote>
     <p>Unicode 制御文字の right-to-left mark 及び left-to-right mark は、以下に示すように、
 そのまま、又は文字符号か数字符号の参照によって挿入することが可能である。</p>

--- a/wcag20/sources/techniques/html/H34.xml
+++ b/wcag20/sources/techniques/html/H34.xml
@@ -10,7 +10,10 @@
       <success-criterion idref="content-structure-separation-sequence" relationship="cosufficient"/>
    </applies-to>
    <description>
-    <p>この達成方法の目的は、HTML の双方向性アルゴリズムが望ましくない結果を生じるとき時に、それを無効にするために Unicode 制御文字の right-to-left mark と left-to-right mark を用いることである。たとえば、スペース又は句読点のようなニュートラルな文字が異なる方向性のテキストの間に置かれている時に必要となることがある。この達成方法で用いられているコンセプトは、W3C 文書の「<loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.w3.org/International/articles/inline-bidi-markup/">What you need to know about the bidi algorithm and inline markup (双方向アルゴリズムとインラインマークアップを知るために必要なこと)</loc>」に書かれている。</p>
+    <p>この達成方法の目的は、HTML の双方向性アルゴリズムが望ましくない結果を生じるとき時に、それを無効にするために Unicode 制御文字の right-to-left mark と left-to-right mark を用いることである。たとえば、スペース又は句読点のようなニュートラルな文字が異なる方向性のテキストの間に置かれている時に必要となることがある。この達成方法で用いられているコンセプトは、W3C 文書の「<loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.w3.org/International/articles/inline-bidi-markup/">What you need to know about the bidi algorithm and inline markup</loc>」に書かれている。</p>
+    <trnote>
+      <p>上記の「What you need to know about the bidi algorithm and inline markup」は、「Inline markup and bidirectional text in HTML」とタイトルが変更されている。この文書によれば、Unicode の right-to-left mark (RLM) 又は left-to-right mark (LRM) よりも、<code>dir</code> 属性による書字方向の制御が勧められている。<loc href="H56" linktype="html"/>も参照のこと。</p>
+    </trnote>
     <p>Unicode 制御文字の right-to-left mark 及び left-to-right mark は、以下に示すように、
 そのまま、又は文字符号か数字符号の参照によって挿入することが可能である。</p>
     <ulist>

--- a/wcag20/sources/techniques/html/H56.xml
+++ b/wcag20/sources/techniques/html/H56.xml
@@ -11,6 +11,9 @@
    </applies-to>
    <description>
     <p>この達成方法の目的は、入れ子になった表記方向が含まれるテキストについて、インライン要素の <att>dir</att> 属性で方向の変化を指定することである。入れ子になったテキストの表記方向とは、たとえば英語のパラグラフで、文章が次々と続いている中にヘブライ語の引用文が含まれるといった、表記方向の異なるテキストが混在したテキストの表記方向のことである。表記方向の異なるテキストが混在し、スペースや句読点が含まれていると、<loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.w3.org/International/articles/inline-bidi-markup/">Unicode の双方向アルゴリズム</loc>だけでは望ましくない結果になってしまうので、テキストを <el>span</el> 要素や他のインライン要素で囲み、<att>dir</att> 属性を指定する必要がある。この達成方法の考え方は、<loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.w3.org/International/articles/inline-bidi-markup/">What you need to know about the bidi algorithm and inline markup</loc> で説明されている。</p>
+  <trnote>
+    <p>上記の「What you need to know about the bidi algorithm and inline markup」は、「Inline markup and bidirectional text in HTML」とタイトルが変更されている。</p>
+  </trnote>
   </description>
    <examples>
       <eg-group>


### PR DESCRIPTION
related #153

H34、H56への訳注の追加。

「What you need to know about the bidi algorithm and inline markup」が「Inline markup and bidirectional text in HTML」にタイトル変更がされている旨と、その文書では基本的に`dir`属性を使うように勧めているので、その旨の追記