### PR TITLE
strong要素への訳注の追加

### DIFF
--- a/wcag20/sources/techniques/css/C12.xml
+++ b/wcag20/sources/techniques/css/C12.xml
@@ -30,7 +30,7 @@
       <head>CSS でのパーセントによるフォントサイズ指定</head>
       <description><p>この事例では、どのような場合でも、<el>strong</el> 要素のテキストが周りのテキストよりも常に大きく表示されるように指定してある。そのため、親要素である見出しやパラグラフにフォントサイズが指定されていても、<el>strong</el> 要素でマークアップされた強調語は、周りのテキストよりも大きく表示される。</p>
       <trnote>
-        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。</p>
       </trnote>
 </description>
          <code><![CDATA[

--- a/wcag20/sources/techniques/css/C12.xml
+++ b/wcag20/sources/techniques/css/C12.xml
@@ -29,6 +29,9 @@
       <eg-group>
       <head>CSS でのパーセントによるフォントサイズ指定</head>
       <description><p>この事例では、どのような場合でも、<el>strong</el> 要素のテキストが周りのテキストよりも常に大きく表示されるように指定してある。そのため、親要素である見出しやパラグラフにフォントサイズが指定されていても、<el>strong</el> 要素でマークアップされた強調語は、周りのテキストよりも大きく表示される。</p>
+      <trnote>
+        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+      </trnote>
 </description>
          <code><![CDATA[
 strong {font-size: 120%}

--- a/wcag20/sources/techniques/css/C13.xml
+++ b/wcag20/sources/techniques/css/C13.xml
@@ -26,6 +26,9 @@
       <eg-group>
       <head>CSS でのキーワードによるフォントサイズ指定</head>
       <description><p>この事例では、どのような設定であっても、<el>strong</el> 要素のテキストが周りのテキストよりも常に大きく表示されるように、「larger」というフォントサイズが指定してある。親要素である見出しやパラグラフにフォントサイズが指定されていても、strong 要素でマークアップされた強調語は、周りのテキストよりも大きく表示されるだろう。</p>
+      <trnote>
+        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+      </trnote>
 </description>
          <code><![CDATA[
 strong {font-size: larger}

--- a/wcag20/sources/techniques/css/C13.xml
+++ b/wcag20/sources/techniques/css/C13.xml
@@ -27,7 +27,7 @@
       <head>CSS でのキーワードによるフォントサイズ指定</head>
       <description><p>この事例では、どのような設定であっても、<el>strong</el> 要素のテキストが周りのテキストよりも常に大きく表示されるように、「larger」というフォントサイズが指定してある。親要素である見出しやパラグラフにフォントサイズが指定されていても、strong 要素でマークアップされた強調語は、周りのテキストよりも大きく表示されるだろう。</p>
       <trnote>
-        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。</p>
       </trnote>
 </description>
          <code><![CDATA[

--- a/wcag20/sources/techniques/css/C14.xml
+++ b/wcag20/sources/techniques/css/C14.xml
@@ -33,7 +33,7 @@
       <head>CSS での em によるフォントサイズ指定</head>
       <description><p>この事例では、どのような場合でも、<el>strong</el> 要素のテキストが周りのテキストよりも常に大きく表示されるように指定してある。そのため、親要素である見出しやパラグラフにフォントサイズが指定されていても、strong 要素でマークアップされた強調語は、周りのテキストよりも大きく表示される。</p>
       <trnote>
-        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。</p>
       </trnote>
 </description>
          <code><![CDATA[

--- a/wcag20/sources/techniques/css/C14.xml
+++ b/wcag20/sources/techniques/css/C14.xml
@@ -32,6 +32,9 @@
       <eg-group>
       <head>CSS での em によるフォントサイズ指定</head>
       <description><p>この事例では、どのような場合でも、<el>strong</el> 要素のテキストが周りのテキストよりも常に大きく表示されるように指定してある。そのため、親要素である見出しやパラグラフにフォントサイズが指定されていても、strong 要素でマークアップされた強調語は、周りのテキストよりも大きく表示される。</p>
+      <trnote>
+        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+      </trnote>
 </description>
          <code><![CDATA[
 strong {font-size: 1.6em}

--- a/wcag20/sources/techniques/css/C22.xml
+++ b/wcag20/sources/techniques/css/C22.xml
@@ -107,7 +107,7 @@
 </description>
       <code><![CDATA[strong.largersize { font-size: 1.5em; }]]></code>
 <trnote>
-<p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong">MDN の strong 要素</a>で示されているように、現在の HTML では <code>strong</code> を重要性を表すものと定義している。従って、文字を大きくする目的のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+<p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong">MDN の strong 要素</a>で示されているように、現在の HTML では <code>strong</code> を重要性を表すものと定義している。</p>
 </trnote>
     </eg-group>
     <eg-group>

--- a/wcag20/sources/techniques/css/C22.xml
+++ b/wcag20/sources/techniques/css/C22.xml
@@ -106,6 +106,9 @@
       <description><p>CSS:</p>
 </description>
       <code><![CDATA[strong.largersize { font-size: 1.5em; }]]></code>
+<trnote>
+<p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong">MDN の strong 要素</a>で示されているように、現在の HTML では <code>strong</code> を重要性を表すものと定義している。従って、文字を大きくする目的のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+</trnote>
     </eg-group>
     <eg-group>
       <head>テキストの色を制御するために CSS の color を使用する。</head>

--- a/wcag20/sources/techniques/general/G115.xml
+++ b/wcag20/sources/techniques/general/G115.xml
@@ -58,6 +58,9 @@
     </eg-group>
     <eg-group>
       <description><p>この事例では、テキストを強調するために <el>em</el> 及び <el>strong</el> 要素をどのように用いたらよいかを示している。</p>
+      <trnote>
+        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> 要素を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+      </trnote>
 </description>
          <code role="html401"><![CDATA[
               <p>What she <em>really</em> meant to say was, 

--- a/wcag20/sources/techniques/general/G115.xml
+++ b/wcag20/sources/techniques/general/G115.xml
@@ -59,7 +59,7 @@
     <eg-group>
       <description><p>この事例では、テキストを強調するために <el>em</el> 及び <el>strong</el> 要素をどのように用いたらよいかを示している。</p>
       <trnote>
-        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> 要素を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> 要素を重要性を表すものと定義している。</p>
       </trnote>
 </description>
          <code role="html401"><![CDATA[

--- a/wcag20/sources/techniques/general/G117.xml
+++ b/wcag20/sources/techniques/general/G117.xml
@@ -18,6 +18,9 @@
       <head>新しいコンテンツをボールドの文字とテキストで示す</head>
       <description>
             <p>以下の例はアクセシビリティ標準のリストである。WCAG 2.0 は新しいため、ボールドで表示されている。視覚のみで情報が提供されることを避けるため、「(new)」という単語も後ろにつけている。</p>
+        <trnote>
+          <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cb%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、単に字を太くする目的であれば、<code>b</code> 要素を使用するのが適切である。</p>
+        </trnote>
       </description>
       <code><![CDATA[
           <h2>Web Accessibility Guidelines</h2>

--- a/wcag20/sources/techniques/general/G138.xml
+++ b/wcag20/sources/techniques/general/G138.xml
@@ -21,7 +21,7 @@
       <head>:必須のフォーム項目に対して、色と強調を用いる</head>
       <description><p>HTML のフォームにいくつかの必須項目がある。必須項目のラベルは赤で表示されている。加えて、各ラベルのテキストは強い強調を示すために <el>strong</el> 要素でマークアップされている。フォーム入力の説明文には、「すべての必須項目は赤で表示されており、強調されている」とあり、事例が添えられている。</p>
       <trnote>
-        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong>/code> を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
       </trnote>
 </description>
     </eg-group>

--- a/wcag20/sources/techniques/general/G138.xml
+++ b/wcag20/sources/techniques/general/G138.xml
@@ -21,7 +21,7 @@
       <head>:必須のフォーム項目に対して、色と強調を用いる</head>
       <description><p>HTML のフォームにいくつかの必須項目がある。必須項目のラベルは赤で表示されている。加えて、各ラベルのテキストは強い強調を示すために <el>strong</el> 要素でマークアップされている。フォーム入力の説明文には、「すべての必須項目は赤で表示されており、強調されている」とあり、事例が添えられている。</p>
       <trnote>
-        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。</p>
       </trnote>
 </description>
     </eg-group>

--- a/wcag20/sources/techniques/general/G138.xml
+++ b/wcag20/sources/techniques/general/G138.xml
@@ -20,6 +20,9 @@
       <eg-group>
       <head>:必須のフォーム項目に対して、色と強調を用いる</head>
       <description><p>HTML のフォームにいくつかの必須項目がある。必須項目のラベルは赤で表示されている。加えて、各ラベルのテキストは強い強調を示すために <el>strong</el> 要素でマークアップされている。フォーム入力の説明文には、「すべての必須項目は赤で表示されており、強調されている」とあり、事例が添えられている。</p>
+      <trnote>
+        <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong>/code> を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+      </trnote>
 </description>
     </eg-group>
    </examples>

--- a/wcag20/sources/techniques/html/H49.xml
+++ b/wcag20/sources/techniques/html/H49.xml
@@ -38,6 +38,9 @@
               <!--linktype="examples"-->セマンティックなテキストのレンダリング例</loc>を参照。</p>
       <eg-group>
       <description><p>この事例では、テキストの強調に <el>em</el> 要素と <el>strong</el> 要素を利用する方法を示している。<el>em</el> 要素と <el>strong</el> 要素は、構造的な強調を示すのに用意されているものであり、さまざまな形式で描画されうる (フォントスタイルの変更、読み上げ時の抑揚の変更など)。</p>
+        <trnote>
+          <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+        </trnote>
 </description>
          <code role="html401"><![CDATA[ ...What she <em>really</em> meant to say was, &quot;This is not ok, 
  it is <strong>excellent</strong>&quot;!... ]]></code>

--- a/wcag20/sources/techniques/html/H49.xml
+++ b/wcag20/sources/techniques/html/H49.xml
@@ -39,7 +39,7 @@
       <eg-group>
       <description><p>この事例では、テキストの強調に <el>em</el> 要素と <el>strong</el> 要素を利用する方法を示している。<el>em</el> 要素と <el>strong</el> 要素は、構造的な強調を示すのに用意されているものであり、さまざまな形式で描画されうる (フォントスタイルの変更、読み上げ時の抑揚の変更など)。</p>
         <trnote>
-          <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。従って、強調のために <code>strong</code> 要素を用いるのは適切ではない。</p>
+          <p><a href="https://developer.mozilla.org/ja/docs/Web/HTML/Element/strong#%3Cem%3E_vs._%3Cstrong%3E">MDN の strong 要素</a>で示されているように、古い HTML では <code>strong</code> 要素を単により強い強調としていたが、現在の HTML では <code>strong</code> を重要性を表すものと定義している。</p>
         </trnote>
 </description>
          <code role="html401"><![CDATA[ ...What she <em>really</em> meant to say was, &quot;This is not ok, 


### PR DESCRIPTION
related #153

HTML4でいうところの、より強い強調として `strong` を用いている箇所が多数（今日のHTMLでは重要性を表すために用いる）なので、それに対しての訳注を追記（G115-ex4、G117-ex1,、138、H49-ex1、C12、C13、C14、C22-ex3）。
