### PR TITLE
DOMの訳注の追加

### DIFF
--- a/wcag20/sources/techniques/client-side-script/SCR21.xml
+++ b/wcag20/sources/techniques/client-side-script/SCR21.xml
@@ -205,6 +205,9 @@ function focusFormField(objAnchor, objEvent, objForm)
           <p>(ソースコードを検証して、) 新しいコンテンツが document.write()、innerHTML、outerHTML、innerText 又は outerText を用いて作成されていない。</p>
         </item>
       </olist>
+      <trnote>
+        <p><a href="#SCR21-description">解説</a>の訳注で示した <code>document.write()</code>、<code>innerHTML</code> に加えて、<code>outerHTML</code> は 2018 年現在、<a href="https://w3c.github.io/DOM-Parsing/#dfn-outerhtml">DOM Parsing and Serialization</a> 仕様で定義されており、<code>innerText</code> は <a href="https://www.w3.org/TR/html52/dom.html#the-innertext-idl-attribute">HTML 5.2§3.2.6. The innerText IDL attribute</a> で定義されている。したがって、手順 1 に示されるものに関しては、<code>outerText</code> のみが非標準である。<a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/outerText">HTMLElement.outerText - Web APIs | MDN</a> も参照のこと。</p>
+      </trnote>
     </procedure>
       <expected-results>
          <ulist>

--- a/wcag20/sources/techniques/client-side-script/SCR21.xml
+++ b/wcag20/sources/techniques/client-side-script/SCR21.xml
@@ -21,7 +21,7 @@
   </note>
   <trnote>
     <p><a href="https://www.w3.org/TR/html52/webappapis.html#documentwrite">HTML 5.2§7.4.3. document.write()</a> の Warning でも述べられているように、たとえ HTML (MIME タイプ text/html) であっても <code>document.write()</code> の使用は勧められていない。</p>
-    <p><code>innerHTML</code> は 2018 年現在、<a href="https://w3c.github.io/DOM-Parsing/#dfn-innerhtml">DOM Parsing and Serialization</a> 仕様で定義されている。したがって、本文で述べられている DOM の仕様ではないというのは今日では当てはまらない。</p>
+    <p><code>innerHTML</code> は 2018 年現在、<a href="https://w3c.github.io/DOM-Parsing/#dfn-innerhtml">DOM Parsing and Serialization</a> 仕様で定義されている。</p>
   </trnote>
       <a11ysuprorted rating="good" exnumber="0"/>
   </description>

--- a/wcag20/sources/techniques/client-side-script/SCR21.xml
+++ b/wcag20/sources/techniques/client-side-script/SCR21.xml
@@ -19,6 +19,10 @@
     <p>この達成方法の目的は、<code>document.write</code> 又は <code>object.innerHTML</code> の代わりに Document Object Model (DOM) の機能を用いて、ページ中にコンテンツを追加することである。<code>document.write()</code> メソッドは XHTML で正しい MIME タイプ (application/xhtml+xml) が指定されているときに動作せず、<code>innerHTML</code> プロパティは DOM の仕様ではないため利用すべきでない。もし DOM の機能を利用してコンテンツを追加すれば、ユーザエージェントは DOM にアクセスしてコンテンツを取り込むことができる。<code>createElement()</code> 関数を使って DOM の中に要素を作成することもできる。<code>createTextNode()</code> は要素に関連付けられたテキストを作成するのに用いられる。<code>appendChild()</code>、<code>removeChild()</code>、<code>insertBefore()</code> 及び <code>replaceChild()</code> 関数は、要素やノードを追加したり削除したりするのに用いられる。その他の DOM 関数は、作成された要素に属性を与えるときに使用される。</p>
     <note><p>フォーカス可能な要素を文書に追加するとき、<att>tabindex</att> 属性を用いて明示的なタブ順序を指定してはならない。なぜなら、文書の中央にフォーカス可能な要素を追加するときに問題が発生するからである。<att>tabindex</att> 属性を明示的に設定しないことで、デフォルトのタブ順序が新しい要素に割り当てられるようにする。</p>
   </note>
+  <trnote>
+    <p><a href="https://www.w3.org/TR/html52/webappapis.html#documentwrite">HTML 5.2§7.4.3. document.write()</a> の Warning でも述べられているように、たとえ HTML (MIME タイプ text/html) であっても <code>document.write()</code> の使用は勧められていない。</p>
+    <p><code>innerHTML</code> は 2018 年現在、<a href="https://w3c.github.io/DOM-Parsing/#dfn-innerhtml">DOM Parsing and Serialization</a> 仕様で定義されている。したがって、本文で述べられている DOM の仕様ではないというのは今日では当てはまらない。</p>
+  </trnote>
       <a11ysuprorted rating="good" exnumber="0"/>
   </description>
    <examples>


### PR DESCRIPTION
related #153

SCR21に記載されているdocument.write()、innerHTML、outerHTML、innerText、outerTextについて、標準で定義されているかどうかの訳注を追加。