### PR TITLE
開発ツールの訳注の追記

### DIFF
--- a/wcag20/sources/techniques/client-side-script/SCR37.xml
+++ b/wcag20/sources/techniques/client-side-script/SCR37.xml
@@ -155,6 +155,12 @@ function ResetForm(elem)
                <p>
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://getfirebug.com/">Firebug</loc>. Allows examination of script-generated DOM in Firefox. </p>
             </item>
+       <trnote>
+         <p>「Microsoft Internet Explorer Developer Toolbar」はページが削除されているが、代わりに開発者ツールを使用できる。詳細については、<a href="https://msdn.microsoft.com/ja-jp/library/dd565628%28v=vs.85%29.aspx">Internet Explorer 開発者ツールを理解する</a>を参照のこと。</p>
+         <p>Firefox のアドオン「Firebug」は開発が終了している。代わりに開発ツールを使用できる。<a href="https://developer.mozilla.org/ja/docs/Tools">開発ツール | MDN</a> も参照のこと。</p>
+         <p>Google Chrome の場合、類似のツールが利用できる。詳細については、<a href="https://developers.google.com/web/tools/chrome-devtools/?hl=ja">Chrome DevTools  |  Tools for Web Developers  |  Google Developers</a> を参照のこと。</p>
+         <p>Edge の場合も、類似のツールが利用できる。詳細については、<a href="https://docs.microsoft.com/ja-jp/microsoft-edge/devtools-guide">Microsoft Edge Developer Tools - Microsoft Edge Development | Microsoft Docs</a> を参照のこと。</p>
+        </trnote>
          </ulist>
       </see-also>
    </resources>

--- a/wcag20/sources/techniques/css/C27.xml
+++ b/wcag20/sources/techniques/css/C27.xml
@@ -44,6 +44,12 @@
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://getfirebug.com/">Firebug</loc> を使用すると、Firefox でスクリプトによって生成された DOM のチェックが可能になる。</p>
             </item>
          </ulist>
+       <trnote>
+         <p>「Microsoft Internet Explorer Developer Toolbar」はページが削除されているが、代わりに開発者ツールを使用できる。詳細については、<a href="https://msdn.microsoft.com/ja-jp/library/dd565628%28v=vs.85%29.aspx">Internet Explorer 開発者ツールを理解する</a>を参照のこと。</p>
+         <p>Firefox のアドオン「Firebug」は開発が終了している。代わりに開発ツールを使用できる。<a href="https://developer.mozilla.org/ja/docs/Tools">開発ツール | MDN</a> も参照のこと。</p>
+         <p>Google Chrome の場合、類似のツールが利用できる。詳細については、<a href="https://developers.google.com/web/tools/chrome-devtools/?hl=ja">Chrome DevTools  |  Tools for Web Developers  |  Google Developers</a> を参照のこと。</p>
+         <p>Edge の場合も、類似のツールが利用できる。詳細については、<a href="https://docs.microsoft.com/ja-jp/microsoft-edge/devtools-guide">Microsoft Edge Developer Tools - Microsoft Edge Development | Microsoft Docs</a> を参照のこと。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/failures/F86.xml
+++ b/wcag20/sources/techniques/failures/F86.xml
@@ -67,6 +67,12 @@
                   <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://getfirebug.com/">Firebug</loc>. Allows examination of script-generated DOM in Firefox.</p>
             </item>
          </ulist>
+       <trnote>
+         <p>「Microsoft Internet Explorer Developer Toolbar」はページが削除されているが、代わりに開発者ツールを使用できる。詳細については、<a href="https://msdn.microsoft.com/ja-jp/library/dd565628%28v=vs.85%29.aspx">Internet Explorer 開発者ツールを理解する</a>を参照のこと。</p>
+         <p>Firefox のアドオン「Firebug」は開発が終了している。代わりに開発ツールを使用できる。<a href="https://developer.mozilla.org/ja/docs/Tools">開発ツール | MDN</a> も参照のこと。</p>
+         <p>Google Chrome の場合、類似のツールが利用できる。詳細については、<a href="https://developers.google.com/web/tools/chrome-devtools/?hl=ja">Chrome DevTools  |  Tools for Web Developers  |  Google Developers</a> を参照のこと。</p>
+         <p>Edge の場合も、類似のツールが利用できる。詳細については、<a href="https://docs.microsoft.com/ja-jp/microsoft-edge/devtools-guide">Microsoft Edge Developer Tools - Microsoft Edge Development | Microsoft Docs</a> を参照のこと。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/server-side-script/SVR5.xml
+++ b/wcag20/sources/techniques/server-side-script/SVR5.xml
@@ -68,6 +68,9 @@ public void doGet(HttpServletRequest request, HttpServletResponse response)
       <olist>
         <item>
           <p>Live HTTP Header ビューアを用いて、"Content-Language" ヘッダーの値を確認する。</p>
+<trnote>
+<p>「Live HTTP Header」が正確に何を指すのか不明であるが、代わりに各種ブラウザの開発ツールで確かめることができる。<a href="https://developers.google.com/web/tools/chrome-devtools/network-performance/resource-loading?hl=ja">リソース読み込み時間の測定  |  Tools for Web Developers  |  Google Developers</a>、<a href="https://developer.mozilla.org/ja/docs/Tools/Network_Monitor">ネットワークモニター - 開発ツール | MDN</a>、<a href="https://docs.microsoft.com/ja-jp/microsoft-edge/devtools-guide/network">Microsoft Edge DevTools - Network - Microsoft Edge Development | Microsoft Docs</a> がそれぞれ参考になる。</p>
+</trnote>
         </item>
         <item>
           <p>その値がウェブページの主たる自然言語と合致している。</p>


### PR DESCRIPTION
related #153

### F86/C27/SCR37 について

- 参考リソースでMicrosoft Internet Explorer Developer Toolbarおよび、Firebugという時代遅れのツールを紹介しているので、代わりにいわゆるF12ツールへ誘導している。
- あわせて、ChromeとEdgeについても、参考となるリソースを紹介している。（いずれも、公式ページ）。

### SVR5について
- 検証の手順1でLive HTTP Header (Live HTTP Headersのことか？)を挙げているが、F12ツールで代用可能なので、Firefox、Chrome、Edgeのリソースを紹介している。
