### PR TITLE
WAI-ARIA Authoring Practicesの訳注の追加

### DIFF
--- a/wcag20/sources/techniques/aria/ARIA12.xml
+++ b/wcag20/sources/techniques/aria/ARIA12.xml
@@ -32,7 +32,7 @@
       <p>可能な場合、ネイティブな見出しマークアップを直接使用すること。たとえば、<code><![CDATA[<div role="heading" aria-level="1">]]></code> を使用するのではなく、<el>h1</el> を使用するのが好ましい。しかし、見出しマークアップの代わりに heading ロールを使用することが必要な場合がある。たとえば、スクリプトが既存の要素の階層構造に依存しているレガシーサイトを改装する場合などである。</p>
       <p><prop>heading</prop> ロールとネスティングレベルの用途については、<loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.w3.org/WAI/PF/aria-practices/#kbd_layout_nesting">WAI-ARIA 1.0 Authoring Practices</loc> で説明されている。</p>
       <trnote>
-        <p><prop>heading</prop> ロールとネスティングレベルの用途に関する「WAI-ARIA 1.0 Authoring Practices」のリンクは、正しくは <a href="https://www.w3.org/TR/2013/WD-wai-aria-practices-20130307/#kbd_layout_nesting">WAI-ARIA 1.0 Authoring Practices§3.2.7.3. Implicit Nesting and Headings</a> となる。しかしながら、この文書は古い文書であり、最新のAuthoring Practices である <a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a> において、対応する記述は見当たらないことに注意する。</p>
+        <p><prop>heading</prop> ロールとネスティングレベルの用途に関する「WAI-ARIA 1.0 Authoring Practices」のリンクは、正しくは <a href="https://www.w3.org/TR/2013/WD-wai-aria-practices-20130307/#kbd_layout_nesting">WAI-ARIA 1.0 Authoring Practices§3.2.7.3. Implicit Nesting and Headings</a> となる。しかしながら、この文書は古い文書であり、最新の　Authoring Practices である <a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a> において、対応する記述は見当たらないことに注意する。</p>
       </trnote>
    </description>
    <examples>

--- a/wcag20/sources/techniques/aria/ARIA12.xml
+++ b/wcag20/sources/techniques/aria/ARIA12.xml
@@ -31,6 +31,9 @@
       <p>ページ上に複数の見出しがあり、かつ見出し階層が視覚的なプレゼンテーションを通して定義される場合、見出しの階層レベルを示すために <att>aria-level</att> 属性が使用されるべきである。</p>
       <p>可能な場合、ネイティブな見出しマークアップを直接使用すること。たとえば、<code><![CDATA[<div role="heading" aria-level="1">]]></code> を使用するのではなく、<el>h1</el> を使用するのが好ましい。しかし、見出しマークアップの代わりに heading ロールを使用することが必要な場合がある。たとえば、スクリプトが既存の要素の階層構造に依存しているレガシーサイトを改装する場合などである。</p>
       <p><prop>heading</prop> ロールとネスティングレベルの用途については、<loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.w3.org/WAI/PF/aria-practices/#kbd_layout_nesting">WAI-ARIA 1.0 Authoring Practices</loc> で説明されている。</p>
+      <trnote>
+        <p><prop>heading</prop> ロールとネスティングレベルの用途に関する「WAI-ARIA 1.0 Authoring Practices」のリンクは、正しくは <a href="https://www.w3.org/TR/2013/WD-wai-aria-practices-20130307/#kbd_layout_nesting">WAI-ARIA 1.0 Authoring Practices§3.2.7.3. Implicit Nesting and Headings</a> となる。しかしながら、この文書は古い文書であり、最新のAuthoring Practices である <a href="https://www.w3.org/TR/wai-aria-practices-1.1/">WAI-ARIA Authoring Practices 1.1</a> において、対応する記述は見当たらないことに注意する。</p>
+      </trnote>
    </description>
    <examples>
       <eg-group>

--- a/wcag20/sources/techniques/aria/ARIA19.xml
+++ b/wcag20/sources/techniques/aria/ARIA19.xml
@@ -61,6 +61,9 @@
       <p>この達成方法の目的は、入力エラーが発生した場合に支援技術 (AT) に通知することである。<att>aria-live</att> 属性は、エラーメッセージがライブ領域のコンテナに注入された際に、AT (スクリーンリーダーなど) による通知を可能にする。<att>aria-live</att> 領域内部のコンテンツは、テキストが表示されている場所で AT がフォーカスする必要なしに、AT によって自動的に読みあげられる。</p>
       <p>ライブ領域のプロパティを直接適用する代わりに使用できる<loc xmlns:xlink="http://www.w3.org/1999/xlink"
               href="http://www.w3.org/WAI/PF/aria-practices/#chobet">特殊ケースのライブ領域のロール</loc>も多数ある。</p>
+      <trnote>
+        <p>「特殊ケースのライブ領域のロール」のリンクは、正しくは <a href="https://www.w3.org/TR/2013/WD-wai-aria-practices-20130307/#chobet">WAI-ARIA 1.0 Authoring Practices§5.3. Choosing Between Special Case Live Regions</a> となる。しかしながら、この文書は古い文書である。ライブ領域のロールについては、<a href="https://www.w3.org/TR/wai-aria-1.1/#live_region_roles">WAI-ARIA 1.1§5.3.5 Live Region Roles</a> も参照されたい。</p>
+      </trnote>
    </description>
    <examples>
       <eg-group>

--- a/wcag20/sources/techniques/aria/ARIA4.xml
+++ b/wcag20/sources/techniques/aria/ARIA4.xml
@@ -138,6 +138,9 @@
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>「WAI-ARIA 1.1 Authoring Practices」は、「WAI-ARIA Authoring Practices 1.1」の誤りである。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques/>

--- a/wcag20/sources/techniques/aria/ARIA4.xml
+++ b/wcag20/sources/techniques/aria/ARIA4.xml
@@ -139,7 +139,7 @@
             </item>
          </ulist>
         <trnote>
-          <p>「WAI-ARIA 1.1 Authoring Practices」は、「WAI-ARIA Authoring Practices 1.1」の誤りである。</p>
+          <p>「WAI-ARIA 1.1 Authoring Practices」は、正しくは「WAI-ARIA Authoring Practices 1.1」となる。</p>
         </trnote>
       </see-also>
    </resources>

--- a/wcag20/sources/techniques/failures/F15.xml
+++ b/wcag20/sources/techniques/failures/F15.xml
@@ -50,7 +50,7 @@
             </item>
          </ulist>
         <trnote>
-          <p>「WAI-ARIA 1.0 Authoring Practices」は、「WAI-ARIA Authoring Practices 1.1」の誤りである。</p>
+          <p>「WAI-ARIA 1.0 Authoring Practices」は、正しくは「WAI-ARIA Authoring Practices 1.1」となる。</p>
         </trnote>
       </see-also>
    </resources>

--- a/wcag20/sources/techniques/failures/F15.xml
+++ b/wcag20/sources/techniques/failures/F15.xml
@@ -49,6 +49,9 @@
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>「WAI-ARIA 1.0 Authoring Practices」は、「WAI-ARIA Authoring Practices 1.1」の誤りである。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques/>

--- a/wcag20/sources/techniques/failures/F59.xml
+++ b/wcag20/sources/techniques/failures/F59.xml
@@ -60,6 +60,9 @@
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>「WAI-ARIA 1.0 Authoring Practices」は、「WAI-ARIA Authoring Practices 1.1」の誤りである。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/failures/F59.xml
+++ b/wcag20/sources/techniques/failures/F59.xml
@@ -61,7 +61,7 @@
             </item>
          </ulist>
         <trnote>
-          <p>「WAI-ARIA 1.0 Authoring Practices」は、「WAI-ARIA Authoring Practices 1.1」の誤りである。</p>
+          <p>「WAI-ARIA 1.0 Authoring Practices」は、正しくは「WAI-ARIA Authoring Practices 1.1」となる。</p>
         </trnote>
       </see-also>
    </resources>

--- a/wcag20/sources/techniques/failures/F63.xml
+++ b/wcag20/sources/techniques/failures/F63.xml
@@ -72,7 +72,7 @@ travel on the world's first commercial tourism flights to space.</p>
             </item>
          </ulist>
         <trnote>
-          <p>「WAI-ARIA 1.0 Authoring Practices」は、「WAI-ARIA Authoring Practices 1.1」の誤りである。</p>
+          <p>「WAI-ARIA 1.0 Authoring Practices」は、正しくは「WAI-ARIA Authoring Practices 1.1」となる。</p>
         </trnote>
       </see-also>
    </resources>

--- a/wcag20/sources/techniques/failures/F63.xml
+++ b/wcag20/sources/techniques/failures/F63.xml
@@ -71,6 +71,9 @@ travel on the world's first commercial tourism flights to space.</p>
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>「WAI-ARIA 1.0 Authoring Practices」は、「WAI-ARIA Authoring Practices 1.1」の誤りである。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>


### PR DESCRIPTION
related #153

「WAI-ARIA 1.(0|1) Authoring Practices」は、「WAI-ARIA Authoring Practices 1.1」の誤りなので、その旨の訳注の追加（ARIA4、F15、F59、F63）。

さらにARIA12、ARIA19の解説にあるリンクについても訳注を付与。