### PR TITLE
HTTP RFCの訳注の追記

### DIFF
--- a/wcag20/sources/techniques/failures/F58.xml
+++ b/wcag20/sources/techniques/failures/F58.xml
@@ -82,6 +82,10 @@ public void doGet (HttpServletRequest request, HttpServletResponse response)
                                     with Netscape Navigator 1.1. </p>
               </item-->
          </ulist>
+         <trnote>
+           <p>HTTP/1.0 は Informational な RFC であることに注意する。</p>
+           <p>上記の HTTP/1.1 は RFC 2616 を参照しているが、現在は <a href="https://tools.ietf.org/html/rfc7231">RFC 7231</a> で更新・定義されている。</p>
+         </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/failures/F58.xml
+++ b/wcag20/sources/techniques/failures/F58.xml
@@ -84,7 +84,7 @@ public void doGet (HttpServletRequest request, HttpServletResponse response)
          </ulist>
          <trnote>
            <p>HTTP/1.0 は Informational な RFC であることに注意する。</p>
-           <p>上記の HTTP/1.1 は RFC 2616 を参照しているが、現在は <a href="https://tools.ietf.org/html/rfc7231">RFC 7231</a> で更新・定義されている。</p>
+           <p>上記の HTTP/1.1 は RFC 2616 を参照しているが、現在の HTTP ステータスコードは <a href="https://tools.ietf.org/html/rfc7231">RFC 7231</a> で更新・定義されている。</p>
          </trnote>
       </see-also>
    </resources>

--- a/wcag20/sources/understanding/consistent-behavior-no-extreme-changes-context.xml
+++ b/wcag20/sources/understanding/consistent-behavior-no-extreme-changes-context.xml
@@ -44,6 +44,9 @@
                 <loc href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3">HTTP/1.1 Status Code Definitions: Redirection 3xx</loc>.
               </p></item>
 </ulist>
+<trnote>
+<p>上記の HTTP/1.1 は RFC 2616 を参照しているが、現在は RFC 7231 で更新、定義されている。<a href="https://tools.ietf.org/html/rfc7231#section-6.4">RFC 7231§6.4. Redirection 3xx</a> も参照のこと。</p>
+</trnote>
 </div3>
 
 <div3 role="techniques">

--- a/wcag20/sources/understanding/consistent-behavior-no-extreme-changes-context.xml
+++ b/wcag20/sources/understanding/consistent-behavior-no-extreme-changes-context.xml
@@ -45,7 +45,7 @@
               </p></item>
 </ulist>
 <trnote>
-<p>上記の HTTP/1.1 は RFC 2616 を参照しているが、現在は RFC 7231 で更新、定義されている。<a href="https://tools.ietf.org/html/rfc7231#section-6.4">RFC 7231§6.4. Redirection 3xx</a> も参照のこと。</p>
+<p>上記の HTTP/1.1 は RFC 2616 を参照しているが、現在の HTTP ステータスコードは RFC 7231 で更新、定義されている。<a href="https://tools.ietf.org/html/rfc7231#section-6.4">RFC 7231§6.4. Redirection 3xx</a> も参照のこと。</p>
 </trnote>
 </div3>
 


### PR DESCRIPTION
related #153

HTTP/1.0 についてはInformativeなRFCであることの訳注、
HTTP/1.1としてRFC 2616を参照しているものは、（HTTPステータスコードを参照しているので）RFC 7231 で定義されていることを訳注として追記。（F58、Understanding SC 3.2.5。）