### PR TITLE
古いFrefoxアドオンへの訳注の追記

### DIFF
--- a/wcag20/sources/techniques/aria.xml
+++ b/wcag20/sources/techniques/aria.xml
@@ -89,6 +89,9 @@
                      <p>NVDA は、部分的に WAI-ARIA をサポートする。</p>
                   </item>
                </ulist>
+              <trnote>
+               <p>「FireVox」は 2018 年現在、最新の Firefox と互換性がないためにインストールできない。</p>
+              </trnote>
             </div3>
             <div3 id="wai-aria_accessibility_support">
                <head>WAI-ARIA に対するアクセシビリティサポート</head>

--- a/wcag20/sources/techniques/general/G145.xml
+++ b/wcag20/sources/techniques/general/G145.xml
@@ -79,6 +79,9 @@
                 </p>
             </item>
          </ulist>
+        <trnote>
+          <p>「Colour Contrast Analyser」は 2018 年現在、<a href="https://addons.mozilla.org/ja/firefox/">Firefox Add-ons</a> から入手できない状態にある。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques/>

--- a/wcag20/sources/techniques/general/G148.xml
+++ b/wcag20/sources/techniques/general/G148.xml
@@ -74,6 +74,9 @@
                 </p>
             </item>
          </ulist>
+        <trnote>
+          <p>「Colour Contrast Analyser」は 2018 年現在、<a href="https://addons.mozilla.org/ja/firefox/">Firefox Add-ons</a> から入手できない状態にある。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/general/G18.xml
+++ b/wcag20/sources/techniques/general/G18.xml
@@ -77,6 +77,9 @@
                 </p>
             </item>
          </ulist>
+        <trnote>
+          <p>「Colour Contrast Analyser」は 2018 年現在、<a href="https://addons.mozilla.org/ja/firefox/">Firefox Add-ons</a> から入手できない状態にある。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques/>

--- a/wcag20/sources/techniques/general/G183.xml
+++ b/wcag20/sources/techniques/general/G183.xml
@@ -53,6 +53,9 @@
                 </p>
             </item>
          </ulist>
+        <trnote>
+          <p>「Colour Contrast Analyser」は 2018 年現在、<a href="https://addons.mozilla.org/ja/firefox/">Firefox Add-ons</a> から入手できない状態にある。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/html/H59.xml
+++ b/wcag20/sources/techniques/html/H59.xml
@@ -84,6 +84,9 @@
                        href="http://www.subotnik.net/html/link">The 'link'-Element in (X)HTML</loc></p>
             </item>
          </ulist>
+       <trnote>
+          <p>「Link Toolbar extension」は 2018 年現在、最新の Firefox と互換性がないためにインストールできない。</p>
+       </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/html/H69.xml
+++ b/wcag20/sources/techniques/html/H69.xml
@@ -147,6 +147,9 @@
                </ulist>
             </item>
          </ulist>
+        <trnote>
+         <p>「Accessibility Evaluation Toolbar」は 2018 年現在、最新の Firefox と互換性がないためにインストールできない。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/understanding/visual-audio-contrast-contrast.xml
+++ b/wcag20/sources/understanding/visual-audio-contrast-contrast.xml
@@ -89,6 +89,9 @@
 	<item><p><loc href="http://www.vischeck.com/daltonize/runDaltonize.php">Tool to convert images based on color loss so that contrast is restored as luminance contrast when there was only color contrast (that was lost due to color deficiency)</loc></p></item>
 	<item><p><loc href="http://www.456bereastreet.com/archive/200709/10_colour_contrast_checking_tools_to_improve_the_accessibility_of_your_design/">List of color contrast tools</loc></p></item>
 </ulist>
+<trnote>
+  <p>「Colour Contrast Analyser」は 2018 年現在、<a href="https://addons.mozilla.org/ja/firefox/">Firefox Add-ons</a> から入手できない状態にある。</p>
+</trnote>
 </div3>
 
 <div3 role="techniques">

--- a/wcag20/sources/understanding/visual-audio-contrast7.xml
+++ b/wcag20/sources/understanding/visual-audio-contrast7.xml
@@ -82,6 +82,9 @@
 	<item><p><loc href="http://www.dyslexic.com/fonts">Typefaces for Dyslexia</loc></p></item>
 	<item><p><loc href="http://www.dyslexia.com/library/webdesign.htm">Web Design for Dyslexia</loc></p></item>
 </ulist>
+<trnote>
+  <p>「Colour Contrast Analyser」は 2018 年現在、<a href="https://addons.mozilla.org/ja/firefox/">Firefox Add-ons</a> から入手できない状態にある。</p>
+</trnote>
 </div3>
 
 <div3 role="techniques">


### PR DESCRIPTION
related #153

以下に掲げる理由から、インストールができないFirefixアドオンへの訳注。

入手自体はできるが、互換性の問題のためにインストールできないもの
- Link Toolbar extension (H59)
- Accessibility Evaluation Toolbar (H69)
- FireVox (aria)

Colour Contrast Analyserは、<a href="https://addons.mozilla.org/ja/firefox/">Firefox Add-ons</a>から入手自体ができない。(G18, G145, G148, G183, visual-audio-contrast-contrast [1.4.3], visual-audio-contrast7[1.4.6])