### PR TITLE
CSSに関する訳注の追記

### DIFF
--- a/wcag20/sources/techniques/css/C12.xml
+++ b/wcag20/sources/techniques/css/C12.xml
@@ -57,6 +57,9 @@ it is <strong>very</strong> important to let him configure the text size.
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>フォントに関する CSS の仕様は、<a href="https://www.w3.org/TR/css-fonts-3/">CSS Fonts Module Level 3</a> を参照のこと。この仕様が、CSS 2 のフォントに関する記述に取って代わることに注意されたい。<a href="https://www.w3.org/TR/css-2018/">CSS Snapshot 2018</a> も参照のこと。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/css/C13.xml
+++ b/wcag20/sources/techniques/css/C13.xml
@@ -54,6 +54,9 @@ it is <strong>very</strong> important to let him configure the text size.
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>フォントに関する CSS の仕様は、<a href="https://www.w3.org/TR/css-fonts-3/">CSS Fonts Module Level 3</a> を参照のこと。この仕様が、CSS 2 のフォントに関する記述に取って代わることに注意されたい。<a href="https://www.w3.org/TR/css-2018/">CSS Snapshot 2018</a> も参照のこと。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/css/C14.xml
+++ b/wcag20/sources/techniques/css/C14.xml
@@ -60,6 +60,9 @@ it is <strong>very</strong> important to let him configure the text size.  </p>
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>フォントに関する CSS の仕様は、<a href="https://www.w3.org/TR/css-fonts-3/">CSS Fonts Module Level 3</a> を参照のこと。この仕様が、CSS 2 のフォントに関する記述に取って代わることに注意されたい。<a href="https://www.w3.org/TR/css-2018/">CSS Snapshot 2018</a> も参照のこと。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/css/C15.xml
+++ b/wcag20/sources/techniques/css/C15.xml
@@ -116,6 +116,9 @@ Windows版のFirefox 2.0とOpera 9.02、SeaMonkey 1.1は、フォームのラベ
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>セレクターに関する仕様は、<a href="https://www.w3.org/TR/selectors-3/">Selectors Level 3</a> を参照のこと。この仕様が、CSS 2 のセレクターに関する記述に取って代わることに注意されたい。<a href="https://www.w3.org/TR/css-2018/">CSS Snapshot 2018</a> も参照のこと。</p>
+        </trnote>
       </see-also>
    </resources>
    <tests>

--- a/wcag20/sources/techniques/css/C18.xml
+++ b/wcag20/sources/techniques/css/C18.xml
@@ -84,6 +84,9 @@
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>padding 及び margin 関連プロパティは、<a href="https://www.w3.org/TR/css-box-3/">CSS Box Model Module Level 3</a> で再定義されている。</p>
+        </trnote>
       </see-also>
    </resources>
    <tests/>

--- a/wcag20/sources/techniques/css/C20.xml
+++ b/wcag20/sources/techniques/css/C20.xml
@@ -86,6 +86,9 @@ CSS プロパティの <code>max-width</code> は、Internet Explorer 6 以前�
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>CSS2 の「Box Model」は、<a href="https://www.w3.org/TR/css-box-3/">CSS Box Model Module Level 3</a> で再定義されている。</p>
+        </trnote>
       </see-also>
    </resources>
    <tests>

--- a/wcag20/sources/techniques/css/C30.xml
+++ b/wcag20/sources/techniques/css/C30.xml
@@ -110,6 +110,9 @@
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>Background に関するプロパティは、<a href="https://www.w3.org/TR/css-backgrounds-3/#the-background">CSS Backgrounds and Borders Module Level 3</a> で再定義されている。この仕様は W3C 勧告ではないが、<a href="https://www.w3.org/TR/css-2018/">CSS Snapshot 2018</a> によれば、今日の CSS を構成する仕様として位置づけられている。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/css/C8.xml
+++ b/wcag20/sources/techniques/css/C8.xml
@@ -45,6 +45,9 @@ M u s e u m
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>「CSS 2: Letter and word spacing」は、<a href="https://www.w3.org/TR/css-text-3/#spacing">CSS Text Module Level 3§8. Spacing</a> で再定義されている。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/css/C9.xml
+++ b/wcag20/sources/techniques/css/C9.xml
@@ -98,6 +98,9 @@ body { background: #ffe url('/images/home-bg.jpg') repeat; }
                        href="http://www.w3.org/TR/1999/REC-html401-19991224/struct/global.html#adef-background">HTML 4.01 specification</loc> には、<code>body</code> 要素の <code>background</code> 属性は非推奨であると記述されている。</p>
             </item>
          </ulist>
+        <trnote>
+          <p>「background property」は、<a href="https://www.w3.org/TR/css-backgrounds-3/#the-background">CSS Backgrounds and Borders Module Level 3§3.10. Backgrounds Shorthand: the background property</a> で再定義されている。この仕様は W3C 勧告ではないが、<a href="https://www.w3.org/TR/css-2018/">CSS Snapshot 2018</a> によれば、今日の CSS を構成する仕様として位置づけられている。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/failures/F24.xml
+++ b/wcag20/sources/techniques/failures/F24.xml
@@ -127,6 +127,9 @@
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>CSS2 の「Assigning property values, Cascading, and Inheritance」は、<a href="https://www.w3.org/TR/css-cascade-3/">CSS Cascading and Inheritance Level 3</a> で再定義されている。この仕様は W3C 勧告ではないが、<a href="https://www.w3.org/TR/css-2018/">CSS Snapshot 2018</a> によれば、今日の CSS を構成する仕様として位置づけられている。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/failures/F4.xml
+++ b/wcag20/sources/techniques/failures/F4.xml
@@ -39,6 +39,9 @@
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>「text-decoration property」は、<a href="https://www.w3.org/TR/css-text-decor-3/#text-decoration-property">CSS Text Decoration Module Level 3§2.4. Text Decoration Shorthand: the text-decoration property</a> で再定義されている。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/techniques/general/G204.xml
+++ b/wcag20/sources/techniques/general/G204.xml
@@ -31,6 +31,9 @@
 								       </p>
             </item>
          </ulist>
+        <trnote>
+          <p>CSS2 の「CSS Box Model」は、<a href="https://www.w3.org/TR/css-box-3/">CSS Box Model Module Level 3</a> で再定義されている。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>

--- a/wcag20/sources/understanding/visual-audio-contrast-scale.xml
+++ b/wcag20/sources/understanding/visual-audio-contrast-scale.xml
@@ -46,6 +46,9 @@
 	<item><p><loc href="http://www.456bereastreet.com/archive/200504/about_fluid_and_fixed_width_layouts/">About fluid and fixed width layouts</loc></p></item>
 	<item><p><loc href="http://cookiecrook.com/AIR/2003/train/accessiblecss.php">Accessible CSS</loc></p></item>
 </ulist>
+<trnote>
+<p>CSS2 の「Box Model」は、<a href="https://www.w3.org/TR/css-box-3/">CSS Box Model Module Level 3</a> で再定義されている。</p>
+</trnote>
 </div3>
 
 <div3 role="techniques">

--- a/wcag20/sources/understanding/visual-audio-contrast-visual-presentation.xml
+++ b/wcag20/sources/understanding/visual-audio-contrast-visual-presentation.xml
@@ -66,6 +66,9 @@
 	<item><p><loc href="http://accessites.org/site/2006/11/designing-for-dyslexics-part-3-of-3">Design for Dyslexics</loc></p></item>
 	<item><p><loc href="http://www.dyslexia.com/library/webdesign.htm">Web Design for Dyslexia</loc></p></item>
 </ulist>
+<trnote>
+<p>CSS2 の「Box Model」は、<a href="https://www.w3.org/TR/css-box-3/">CSS Box Model Module Level 3</a> で再定義されている。</p>
+</trnote>
 </div3>
 
 <div3 role="techniques">


### PR DESCRIPTION
related #153

CSS3でプロパティ等が定義されている場合、そのモジュールについて訳注で追記。
（既に[F87](https://waic.github.io/wcag20/Techniques/F87.html#F87-resources)には類似の訳注がある）

- CSS Box Model (G204, C20, visual-audio-contrast-scale[1.4.4], visual-audio-contrast-visual-presentation[1.4.8], C18)
- CSS Text Decoration (F4)
- CSS Cascading and Inheritance (F24)
- CSS Fonts (C12, C13, C14)
- CSS Text (C8)
- CSS Backgrounds and Borders (C9, C30)
- Selecotrs (C15, と上述のF87)