### PR TITLE
DOM Standardへの訳注の追加

### DIFF
--- a/wcag20/sources/techniques/client-side-script/SCR29.xml
+++ b/wcag20/sources/techniques/client-side-script/SCR29.xml
@@ -123,6 +123,7 @@
          </ulist>
          <trnote>
            <p>「WAI-ARIA Primer, Provision of the keyboard or input focus」が挙げられているが、<a href="https://www.w3.org/TR/wai-aria-primer/">WAI-ARIA 1.0 Primer</a> は作成が破棄されている。代わりに、<a href="https://www.w3.org/TR/2018/NOTE-wai-aria-practices-1.1-20180726/#keyboard">WAI-ARIA Authoring Practices 1.1 §5. Developing a Keyboard Interface</a> を参照できる。</p>
+           <p>DOM 仕様は現在、WHATWG で策定されている。<a href="https://dom.spec.whatwg.org/">DOM Standard</a> も参照のこと。</p>
            <p>MSDN のページ「Internet Explorer, HTML and DHTML Reference, tabIndex Property」が MDN にリダイレクトされているが、これは MSDN の文書が MDN に統合されたためである。このリダイレクト処理の詳細については、<a href="https://blogs.windows.com/msedgedev/2017/10/18/documenting-web-together-mdn-web-docs/">Microsoft Edge Dev Blog</a> 及び<a href="https://news.mynavi.jp/article/20171019-a070/">マイナビニュース</a>を参照されたい。</p>
          </trnote>
       </see-also>

--- a/wcag20/sources/techniques/client-side-script/SCR35.xml
+++ b/wcag20/sources/techniques/client-side-script/SCR35.xml
@@ -118,6 +118,9 @@ function doStuff()
                </p>
             </item>
          </ulist>
+        <trnote>
+          <p>DOM 仕様は現在、WHATWG で策定されている。<a href="https://dom.spec.whatwg.org/">DOM Standard</a> も参照のこと。</p>
+        </trnote>
       </see-also>
    </resources>
    <related-techniques>


### PR DESCRIPTION
related #153

#285 とは別に、W3C DOMへの参照があるものについて、WHATWG DOM へのリンクを追加（SCR29, SCR35）