### PR TITLE
H32のコード例を原文通りに修正

### DIFF
--- a/wcag20/sources/techniques/html/H32.xml
+++ b/wcag20/sources/techniques/html/H32.xml
@@ -16,6 +16,17 @@
       <eg-group>
       <description><p>これは送信ボタンを持つフォームの基本的な事例である。</p>
 </description>
+         <code><![CDATA[
+<form action="http://www.example.com/cgi/subscribe/" method="post"><br /> 
+ <p>Enter your e-mail address to subscribe to our mailing list.</p><br /> 
+ <label for="address">Enter email address:</label><input type="text" 
+ id="address" name="address" /> 
+ <input type="submit" value="Subscribe" /><br /> 
+</form>]]></code>
+    </eg-group>
+    <eg-group>
+      <description><p>次の事例では、利用者が要求したページを転送する (<att>action</att> 属性により指定された) サーバーサイドスクリプトを使用している。</p>
+</description>
          <code><![CDATA[ <form action="http://www.example.com/cgi/redirect/" method="get"><br /> 
     <p>Navigate the site.</p><br /> 
     <select name="dest"><br /> 
@@ -26,20 +37,6 @@
     </select><br /> 
   <input type="submit" value="Go to Page" /><br /> 
   </form> ]]></code>
-    </eg-group>
-    <eg-group>
-      <description><p>次の事例では、利用者が要求したページを転送する (<att>action</att> 属性により指定された) サーバーサイドスクリプトを使用している。</p>
-</description>
-      <code><![CDATA[<form action="http://www.example.com/cgi/redirect/" method="get"><br /> 
-<p>Navigate the site.</p><br /> 
-<select name="dest"><br /> 
-<option value="/index.html">Home</option/><br /> 
-<option value="/blog/index.html">My blog</option/><br /> 
-<option value="/tutorials/index.html">Tutorials</option/><br /> 
-<option value="/search.html">Search</option/><br /> 
-</select><br /> 
-<input type="submit" value="Go" /><br /> 
-</form>  ]]></code>
     </eg-group>
    </examples>
    <resources>


### PR DESCRIPTION
現在の達成方法集では事例1と事例2がほとんど同じコード（！）なので、[W3CレポジトリのXMLコード](https://github.com/w3c/wcag/blob/master/wcag20/sources/techniques/html/H32.xml)をコピーして原文どおりにあわせました。

- https://waic.jp/docs/WCAG-TECHS/H32.html
- https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/H32.html
