### PR TITLE
H91 input type=fileの追記

### DIFF
--- a/wcag20/sources/techniques/html/H91.xml
+++ b/wcag20/sources/techniques/html/H91.xml
@@ -76,6 +76,13 @@
           <td> </td>
         </tr>
         <tr>
+          <td>&lt;input type="file"&gt;</td>
+          <td>編集可能なテキスト</td>
+          <td>そのコントロールに関連付けられた &lt;label&gt; 要素又は 'title' 属性</td>
+          <td>'value' 属性</td>
+          <td> </td>
+        </tr>
+        <tr>
           <td>&lt;input type="checkbox"&gt;</td>
           <td>チェックボックス</td>
           <td>そのコントロールに関連付けられた <code>&lt;label&gt;</code> 要素又は <code>title</code> 属性</td>


### PR DESCRIPTION
H91の訳文で抜けている`input type=file`を追記しました
- https://waic.jp/docs/WCAG-TECHS/H91.html
- https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/H91.html