### PR TITLE
UAサポートノートのリンクの修正

### DIFF
--- a/wcag20/sources/techniques/failures/F89.xml
+++ b/wcag20/sources/techniques/failures/F89.xml
@@ -11,11 +11,6 @@
       <success-criterion idref="navigation-mechanisms-link" relationship="failure"/>
       <success-criterion idref="ensure-compat-rsv" relationship="failure"/>
    </applies-to>
-   <ua-issues>
-    <ua-issue name="" version="">
-      <p>代替テキストがないリンクに対しては、支援技術によってさまざまな修復方法が用いられる。例えばHTMLの場合、支援技術は、<el>a</el>要素の <att>title</att> 属性、又は <el>img</el> 要素の <att>src</att> 属性の値を代替テキストの代わりとして用いることがある。</p>
-    </ua-issue>
-  </ua-issues>
   <description>
     <p>この文書は、画像のような非テキストコンテンツのみで提供されているリンクについて、そしてそのリンクがアクセシブルな名前で特定できないときに起こる失敗例について述べている。リンクのアクセシブルな名前 (name) は <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="http://www.w3.org/TR/wai-aria/roles#textalternativecomputation">Accessible Name Calculation</loc> によって決定される。</p>
     <p>これはテキスト及び画像が同じリンク先に別々にリンクしている場合にも適用される。このケースでは、実装方法 <loc xmlns:xlink="http://www.w3.org/1999/xlink" href="H2" linktype="html"/>は別々のリンク及び望ましくない冗長性を減少させるのに推奨される方法である。</p>

--- a/wcag20/sources/techniques/html/H91.xml
+++ b/wcag20/sources/techniques/html/H91.xml
@@ -11,6 +11,7 @@
       <success-criterion idref="keyboard-operation-all-funcs" relationship="sufficient"/>
       <success-criterion idref="ensure-compat-rsv" relationship="sufficient"/>
    </applies-to>
+   <ua-issues/>
    <description>
     <p>この達成方法の目的は、インタラクティブなユーザインタフェースを構成する要素のキーボード操作及び支援技術との相互運用性を提供するために、標準的な HTML のフォームコントロール及びリンク要素を用いることである。</p>
     <p>ユーザエージェントは、HTML のフォームコントロール及びリンクのキーボード操作を提供している。さらに、ユーザエージェントは、フォームコントロール及びリンクを、アクセシビリティ API に結び付けている。支援技術は、アクセシビリティ API を利用して、役割 (role)、識別名 (name)、状態 (state)、値 (value) といった適切なアクセシビリティ情報を抽出し、それらを利用者に提供している。役割は HTML の要素によって提供され、名前はその要素に関連付けられているテキストによって提供される。値及び状態が適切な要素は、複合的なメカニズムを通じて、それらの値及び状態も支援技術に提示している。</p>


### PR DESCRIPTION
https://waic.jp/docs/WCAG-TECHS/F89.html
https://www.w3.org/TR/WCAG20-TECHS/F89.html

https://waic.jp/docs/WCAG-TECHS/H91.html
https://www.w3.org/TR/WCAG20-TECHS/H91.html

「UAサポートリンクノート」へのリンクが原文と食い違うもの。
F89では、原文にはないのに、日本語訳にある、UAサポートノートへのリンクあり
H91ではその逆で、原文にあるのに、日本語訳にない。
原文レベルでの食い違いはこの2つのみ。

`<ua-issues/>`さえあれば、リンクが生成されるので、空要素を追加している。