### PR TITLE
各注釈の末尾にcontact.jsを追加

### DIFF
--- a/wcag20/sources/slices-techniques-common.xsl
+++ b/wcag20/sources/slices-techniques-common.xsl
@@ -710,6 +710,7 @@
 <p>【注意】 この文書は、W3C ワーキンググループノート <a href="https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/">Techniques for WCAG 2.0 の 2016 年 10 月 7 日時点での最新版</a>を<a href="https://waic.jp/committee/wg4/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> が翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書はあくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://waic.jp/contact/" id="file-issue">翻訳に関するお問い合わせ</a>からご連絡ください。</p>
 <p>【重要】 達成方法のタイトルが英語のままになっているものは、日本語訳を行っていないため、原文 (英語) にリンクしています。</p>
 </div>
+<script src="https://waic.jp/docs/js/translation-contact.js"><xsl:text> </xsl:text></script>
 </xsl:template>
   
 	<xsl:template name="footer-latest-version-ref">

--- a/wcag20/sources/slices-understanding-common.xsl
+++ b/wcag20/sources/slices-understanding-common.xsl
@@ -875,6 +875,7 @@
 <p>【注意】 この文書は、W3C ワーキンググループノート <a href="https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/">Understanding WCAG 2.0 の 2016 年 10 月 7 日時点での最新版</a>を、<a href="https://waic.jp/">ウェブアクセシビリティ基盤委員会 (WAIC)</a> が翻訳して公開しているものです。この文書の正式版は、W3C のサイトにある英語版です。正確な内容については、W3C が公開している原文 (英語) をご確認ください。この翻訳文書はあくまで参考情報であり、翻訳上の誤りが含まれていることがあります。翻訳上の誤りを見つけられた場合は、<a href="https://waic.jp/contact/" id="file-issue">翻訳に関するお問い合わせ</a>からご連絡ください。</p>
 <p>【重要】 原文の Understanding WCAG 2.0 自体、WCAG ワーキンググループによって今後も継続的に修正されていくものと思われます。この文書の内容は、あくまでも参考程度にご覧ください。</p>
 </div>
+<script src="https://waic.jp/docs/js/translation-contact.js"><xsl:text> </xsl:text></script>
 </xsl:template>
 
 	<xsl:template name="footer-latest-version-ref">


### PR DESCRIPTION
翻訳問い合わせリンクをフォームへのリンクに置き換えるJSが動作していないようだという指摘がありました (参考: https://twitter.com/momdo_/status/1135847902134263808 )

調査したところ、slices-understanding-common.xsl の360行目にあるscript要素が overview.html にしか出力されていないように見受けられました。</body>が5つほどあって大変ややこしい状況ですが、注釈の末尾に contact.js を追加すれば良いという発想で <xsl:template name="footer"> の末尾に追加しました (878行目)。

同様の処理を slices-techniques-common.xsl に対しても実施しています。