### PR TITLE
fix: translation of G205 code example

### DIFF
--- a/wcag20/sources/techniques/general/G205.xml
+++ b/wcag20/sources/techniques/general/G205.xml
@@ -17,7 +17,7 @@
       <eg-group>
          <head>HTML フォームの必須項目</head>
          <description>
-            <p>オンラインフォームで「必須項目は赤で示され、(必須) とマーク付けされている。」と指示されている。「(必須)」という手がかりが <code><![CDATA[label]]></code> 要素の中に含まれる。</p>
+            <p>オンラインフォームで「必須項目は赤で示され、(required) とマーク付けされている。」と指示されている。「(required)」という手がかりが <code><![CDATA[label]]></code> 要素の中に含まれる。</p>
          </description>
          <code role="html401"><![CDATA[<label for="lastname" class="required">Last name (required): </label>
 <input id="lastname" type="text" size="25" value=""/>


### PR DESCRIPTION
「G205の事例で、コード例と対応する説明テキストの整合性が取れていない」件を修正しました。
fix: https://github.com/waic/wcag20/issues/401